### PR TITLE
feat: add log handler that can send stuff to OTel handlers

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,0 @@
-import Config
-
-# config :logger,
-#   handle_otp_reports: true,
-#   handle_sasl_reports: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,5 @@
+import Config
+
+# config :logger,
+#   handle_otp_reports: true,
+#   handle_sasl_reports: true

--- a/lib/otel_metric_exporter.ex
+++ b/lib/otel_metric_exporter.ex
@@ -1,6 +1,7 @@
 defmodule OtelMetricExporter do
   use Supervisor
   require Logger
+  alias OtelMetricExporter.OtelApi
   alias OtelMetricExporter.MetricStore
   alias Telemetry.Metrics
 
@@ -44,55 +45,25 @@ defmodule OtelMetricExporter do
   ]
 
   @options_schema NimbleOptions.new!(
-                    metrics: [
-                      type: {:list, {:or, for(x <- @supported_metrics, do: {:struct, x})}},
-                      type_spec: quote(do: list(Metrics.t())),
-                      required: true,
-                      doc: "List of telemetry metrics to track."
-                    ],
-                    otlp_endpoint: [
-                      type: :string,
-                      required: true,
-                      subsection: "OTLP transport",
-                      doc: "Endpoint to send metrics to."
-                    ],
-                    otlp_protocol: [
-                      type: {:in, [:http_protobuf]},
-                      type_spec: quote(do: protocol()),
-                      default: :http_protobuf,
-                      subsection: "OTLP transport",
-                      doc:
-                        "Protocol to use for OTLP export. Currently only :http_protobuf and :http_json are supported."
-                    ],
-                    otlp_headers: [
-                      type: {:map, :string, :string},
-                      default: %{},
-                      subsection: "OTLP transport",
-                      doc: "Headers to send with OTLP requests."
-                    ],
-                    otlp_compression: [
-                      type: {:in, [:gzip, nil]},
-                      default: :gzip,
-                      type_spec: quote(do: compression()),
-                      subsection: "OTLP transport",
-                      doc:
-                        "Compression to use for OTLP requests. Allowed values are `:gzip` and `nil`."
-                    ],
-                    resource: [
-                      type: :map,
-                      default: %{},
-                      doc: "Resource attributes to send with metrics."
-                    ],
-                    export_period: [
-                      type: :pos_integer,
-                      default: :timer.minutes(1),
-                      doc: "Period in milliseconds between metric exports."
-                    ],
-                    name: [
-                      type: :atom,
-                      default: :otel_metric_exporter,
-                      doc: "If you require multiple exporters, give each exporter a unique name."
-                    ]
+                    [
+                      metrics: [
+                        type: {:list, {:or, for(x <- @supported_metrics, do: {:struct, x})}},
+                        type_spec: quote(do: list(Metrics.t())),
+                        required: true,
+                        doc: "List of telemetry metrics to track."
+                      ],
+                      export_period: [
+                        type: :pos_integer,
+                        default: :timer.minutes(1),
+                        doc: "Period in milliseconds between metric exports."
+                      ],
+                      name: [
+                        type: :atom,
+                        default: :otel_metric_exporter,
+                        doc:
+                          "If you require multiple exporters, give each exporter a unique name."
+                      ]
+                    ] ++ OtelApi.public_options()
                   )
 
   @type option() :: unquote(NimbleOptions.option_typespec(@options_schema))

--- a/lib/otel_metric_exporter/application.ex
+++ b/lib/otel_metric_exporter/application.ex
@@ -1,5 +1,6 @@
 defmodule OtelMetricExporter.Application do
   use Application
+  require Logger
 
   @impl true
   def start(_type, _args) do

--- a/lib/otel_metric_exporter/log_accumulator.ex
+++ b/lib/otel_metric_exporter/log_accumulator.ex
@@ -1,0 +1,197 @@
+defmodule OtelMetricExporter.LogAccumulator do
+  @moduledoc false
+  require Logger
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord
+  alias OtelMetricExporter.OtelApi
+  # This module is used as a callback for the logger_olp module.
+  # `:logger_olp` expects certain callbacks, but doesn't define an explicit
+  # behaviour for them, so we're using a GenServer behaviour as an approximation.
+  #
+  # On top of regular GenServer callbacks, `:logger_olp` expects:
+  # - `handle_load(event, state) :: state` - required, this is a new log record
+  # - `reset_state(state) :: state` - optional
+  # - `notify(handler_event, state) :: state` - optional
+  #
+  # Handler events are defined in `:logger_olp` as:
+  # ```elixir
+  #   handler_event ::
+  #     :idle
+  #     | :restart
+  #     | {:flushed, flushed :: non_neg_integer}
+  #     | {:mode_change, old_mode :: mode, new_mode :: mode}
+  #   mode :: :drop | :sync | :async
+  # ```
+  #
+  # `logger_olp` will switch between sync ans async modes depending on the message
+  # queue length. Sync mode means the process that tries to send the logs will block
+  # until the logs are sent. Async mode means the process will return immediately and
+  # send the logs in the background.
+
+  @behaviour GenServer
+
+  @schema NimbleOptions.new!(
+            [
+              metadata: [
+                type: {:list, :atom},
+                default: [],
+                doc: "A list of atoms from metadata to attach as attribute to the log event"
+              ],
+              metadata_map: [
+                type: {:map, :atom, :string},
+                default: %{},
+                doc: """
+                Remapping of metadata keys to different attribute names.
+                Example: Plug adds a `request_id` metadata key to log events, but
+                semantic convention for OTel is to use `http.request.id`. This can be
+                achieved by specifying this field to `%{request_id: "http.request.id"}`
+                """
+              ],
+              debounce_ms: [
+                type: :non_neg_integer,
+                default: 5_000,
+                doc: "Period to accumulate logs before sending them"
+              ],
+              max_buffer_size: [
+                type: :non_neg_integer,
+                default: 10_000,
+                doc: "Max amount of log events to store before sending them"
+              ]
+            ] ++ OtelApi.public_options()
+          )
+
+  @doc false
+  def options_schema(), do: @schema
+
+  defdelegate prepare_log_event(event, config), to: OtelMetricExporter.Protocol
+
+  def check_config(config) do
+    with {:ok, validated} <-
+           NimbleOptions.validate(Map.merge(config, OtelApi.defaults()), @schema) do
+      {:ok, validated}
+    end
+  end
+
+  def init(config) do
+    Process.flag(:trap_exit, true)
+    # Store the handler-specific Finch name in the state
+    {:ok, api, rest} = OtelApi.new(config)
+
+    {:ok,
+     Map.merge(rest, %{
+       api: api,
+       event_queue: [],
+       queue_len: 0,
+       timer_ref: nil,
+       pending_tasks: %{}
+     })}
+  end
+
+  def handle_load(event, state) do
+    state
+    |> add_event(event)
+    |> send_schedule_or_block()
+  end
+
+  def handle_cast({:config_changed, config}, state) do
+    {:ok, api, rest} = OtelApi.new(config)
+
+    {:noreply, Map.merge(state, Map.merge(rest, %{api: api}))}
+  end
+
+  # Do nothing on an empty queue
+  def handle_info(:send_log_batch, %{event_queue: []} = state), do: {:noreply, state}
+
+  def handle_info(:send_log_batch, state)
+      when map_size(state.pending_tasks) < state.api.otlp_concurrent_requests do
+    # We can spin up a new task to send the logs
+    {:noreply, send_events_via_task(state)}
+  end
+
+  # No task budget, so we're blocking on this message
+  def handle_info(:send_log_batch, state) do
+    {:noreply, state |> block_until_any_task_ready() |> send_events_via_task()}
+  end
+
+  def handle_info({ref, result}, state)
+      when is_map_key(state.pending_tasks, ref) do
+    if match?({:error, _}, result) do
+      Logger.debug(
+        "Error sending logs to #{state.api.otlp_endpoint}: #{inspect(elem(result, 1))}"
+      )
+    end
+
+    # Remove the task from the pending tasks map
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, _}, state)
+      when is_map_key(state.pending_tasks, ref) do
+    # Remove the task from the pending tasks map
+    {:noreply, %{state | pending_tasks: Map.delete(state.pending_tasks, ref)}}
+  end
+
+  def terminate(_reason, state) do
+    # Send any remaining logs if possible
+    send_events_via_task(state)
+  end
+
+  # We don't care about event order# If we have a here, because it's all timestamped
+  # and up to the log display to order
+  defp add_event(%{event_queue: queue, queue_len: len} = state, event)
+       when is_struct(event, LogRecord),
+       do: %{state | event_queue: [event | queue], queue_len: len + 1}
+
+  # If we have the maximum number of concurrent requests, block
+  defp send_schedule_or_block(%{pending_tasks: pending_tasks} = state)
+       when map_size(pending_tasks) == state.api.otlp_concurrent_requests do
+    state
+    |> block_until_any_task_ready()
+    |> send_schedule_or_block()
+  end
+
+  # If we have enough events to send, send immediately
+  defp send_schedule_or_block(%{queue_len: len} = state)
+       when len >= state.max_buffer_size do
+    # Send the logs immediately
+    send_events_via_task(state)
+  end
+
+  # If we have a schedule already, do nothing
+  defp send_schedule_or_block(%{timer_ref: ref} = state) when not is_nil(ref), do: state
+
+  defp send_schedule_or_block(%{debounce_ms: debounce_ms} = state) do
+    timer_ref = Process.send_after(self(), :send_log_batch, debounce_ms)
+
+    %{state | timer_ref: timer_ref}
+  end
+
+  defp block_until_any_task_ready(%{pending_tasks: pending_tasks} = state) do
+    # Block via a receive, waiting for a completion message or a down message
+    # from a task that we started
+    receive do
+      {ref, result} when is_map_key(pending_tasks, ref) ->
+        dbg(result)
+        # Remove the task from the pending tasks map
+        %{state | pending_tasks: Map.delete(pending_tasks, ref)}
+
+      {:DOWN, ref, :process, _, _} when is_map_key(pending_tasks, ref) ->
+        # Remove the task from the pending tasks map
+        %{state | pending_tasks: Map.delete(pending_tasks, ref)}
+    end
+  end
+
+  defp send_events_via_task(%{api: api, event_queue: queue} = state) do
+    task =
+      Task.Supervisor.async_nolink(state.task_supervisor, OtelApi, :send_log_events, [
+        api,
+        queue
+      ])
+
+    %{
+      state
+      | event_queue: [],
+        queue_len: 0,
+        pending_tasks: Map.put(state.pending_tasks, task.ref, :pending)
+    }
+  end
+end

--- a/lib/otel_metric_exporter/log_handler.ex
+++ b/lib/otel_metric_exporter/log_handler.ex
@@ -1,0 +1,145 @@
+defmodule OtelMetricExporter.LogHandler do
+  @moduledoc """
+  A Logger handler that forwards log events to OTel collector via OTLP protocol.
+
+  This can be installed as a handler for the `:logger` application.
+
+  Example:
+
+      # Add and configure the handler
+      config :my_app, :logger, [
+        {:handler, OtelMetricExporter.LogHandler, :logger_std_h, %{
+          config: %{
+            metadata_map: %{
+              request_id: "http.request.id"
+            }
+          },
+        }}
+      ]
+
+      # Configure the resource and endpoint
+      config :otel_metric_exporter,
+        otlp_protocol: :http_protobuf,
+        otlp_endpoint: otlp_endpoint,
+        resource: %{
+          name: "metrics",
+          service: %{name: service_name, version: version},
+          instance: %{id: instance_id}
+        }
+
+  It should then be explicitly attached by executing `Logger.add_handlers(:my_app)` in `Application.start/2` callback
+  of your application.
+
+  ## Options
+
+  Options starting with `otlp_` and the `resource` option will be take automatically from the `:otel_metric_exporter`
+  app configuration, but can be overridden when adding the handler.
+
+  #{OtelMetricExporter.LogAccumulator.options_schema() |> NimbleOptions.docs()}
+  """
+
+  alias OtelMetricExporter.LogAccumulator
+  alias OtelMetricExporter.LogHandlerSupervisor
+
+  @behaviour :logger_handler
+
+  @olp_config_keys [
+    :drop_mode_qlen,
+    :flush_qlen,
+    :burst_limit_enable,
+    :burst_limit_max_count,
+    :burst_limit_window_time,
+    :overload_kill_enable,
+    :overload_kill_qlen,
+    :overload_kill_mem_size,
+    :overload_kill_restart_after
+  ]
+
+  @impl true
+  def adding_handler(%{config: config} = handler_config) do
+    {olp_config, accumulator_config} = Map.split(Map.new(config), @olp_config_keys)
+
+    with {:ok, olp_config} <- prevalidate_olp(olp_config),
+         {:ok, config} <- LogAccumulator.check_config(accumulator_config),
+         {:ok, sup_pid, olp} <- start_supervisor(handler_config, config, olp_config) do
+      olp_opts = :logger_olp.get_opts(olp)
+
+      # Register the handler with the logger handler watcher, which detaches the handler
+      # if it crashes for any reason to avoid taking down the entire logger process.
+      :ok = :logger_handler_watcher.register_handler(handler_config.id, sup_pid)
+
+      {:ok, %{handler_config | config: config |> Map.merge(olp_opts) |> Map.put(:olp, olp)}}
+    end
+  end
+
+  defp prevalidate_olp(olp_config) do
+    {:ok, Map.put(olp_config, :sync_mode_qlen, Map.get(olp_config, :drop_mode_qlen, 200))}
+  end
+
+  defp start_supervisor(handler_config, accumulator_config, olp_config) do
+    Supervisor.start_child(
+      :logger_sup,
+      %{
+        LogHandlerSupervisor.child_spec(
+          name: :"#{handler_config.module}_#{handler_config.id}",
+          accumulator_config: accumulator_config,
+          olp_config: olp_config
+        )
+        | id: handler_config.id
+      }
+    )
+  end
+
+  @impl true
+  def changing_config(set_or_update, %{config: %{olp: olp}} = old_config, new_config) do
+    full_config =
+      case set_or_update do
+        :set ->
+          new_config
+
+        :update ->
+          Map.merge(old_config, new_config, fn
+            :config, v1, v2 -> Map.merge(v1, v2)
+            _k, _v1, v2 -> v2
+          end)
+      end
+
+    {olp_config, accumulator_config} = Map.split(full_config.config, @olp_config_keys)
+
+    with {:ok, olp_config} <- prevalidate_olp(olp_config),
+         {:ok, config} <- LogAccumulator.check_config(accumulator_config),
+         :ok <- :logger_olp.set_opts(olp, olp_config) do
+      :logger_olp.cast(olp, {:config_changed, config})
+      {:ok, %{full_config | config: config |> Map.merge(olp_config)}}
+    end
+  end
+
+  @impl true
+  def filter_config(config) do
+    config
+  end
+
+  @impl true
+  def log(event, %{config: %{olp: olp} = config}) do
+    true = Process.alive?(:logger_olp.get_pid(olp))
+    :logger_olp.load(olp, LogAccumulator.prepare_log_event(event, config))
+  end
+
+  @impl true
+  def removing_handler(handler_config) do
+    supervisor_name = reg_name(handler_config, "Supervisor")
+
+    case Process.whereis(supervisor_name) do
+      nil ->
+        :ok
+
+      supervisor_pid ->
+        # Stop the supervisor and all its children
+        Supervisor.stop(supervisor_pid, :normal)
+        :ok
+    end
+  end
+
+  defp reg_name(prefix, part) when is_binary(prefix) or is_atom(prefix), do: :"#{prefix}_#{part}"
+  defp reg_name(%{module: module, id: id}, part), do: :"#{module}_#{id}_#{part}"
+end

--- a/lib/otel_metric_exporter/log_handler_supervisor.ex
+++ b/lib/otel_metric_exporter/log_handler_supervisor.ex
@@ -1,0 +1,68 @@
+defmodule OtelMetricExporter.LogHandlerSupervisor do
+  @moduledoc false
+  use Supervisor, shutdown: 10_000, restart: :temporary
+
+  def start_link(args) do
+    base_name = args[:name]
+
+    accumulator_config =
+      args[:accumulator_config]
+      |> Map.put(:finch, :"#{base_name}_Finch")
+      |> Map.put(:task_supervisor, :"#{base_name}_TaskSupervisor")
+
+    case Supervisor.start_link(__MODULE__, accumulator_config, name: base_name) do
+      {:ok, supervisor_pid} ->
+        case Supervisor.start_child(
+               supervisor_pid,
+               logger_olp_child_spec(
+                 :"#{base_name}_logger_olp",
+                 accumulator_config,
+                 args[:olp_config]
+               )
+             ) do
+          {:ok, _, olp} ->
+            {:ok, supervisor_pid, olp}
+
+          {:error, {reason, child}} when is_tuple(child) and elem(child, 0) == :child ->
+            {:error, reason}
+
+          error ->
+            error
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp logger_olp_child_spec(reg_name, accumulator_config, olp_config) do
+    %{
+      id: :logger_olp,
+      start:
+        {:logger_olp, :start_link,
+         [
+           reg_name,
+           OtelMetricExporter.LogAccumulator,
+           accumulator_config,
+           olp_config
+         ]},
+      restart: :transient,
+      significant: true,
+      shutdown: 5000,
+      type: :worker,
+      modules: [OtelMetricExporter.LogAccumulator]
+    }
+  end
+
+  @impl true
+  def init(accumulator_config) do
+    children = [
+      {Finch,
+       name: accumulator_config[:finch],
+       pools: %{:default => [size: accumulator_config[:otlp_concurrent_requests], count: 1]}},
+      {Task.Supervisor, name: accumulator_config[:task_supervisor]}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)
+  end
+end

--- a/lib/otel_metric_exporter/opentelemetry/proto/collector/logs/v1/logs_service.pb.ex
+++ b/lib/otel_metric_exporter/opentelemetry/proto/collector/logs/v1/logs_service.pb.ex
@@ -1,0 +1,31 @@
+defmodule OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:resource_logs, 1,
+    repeated: true,
+    type: OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ResourceLogs,
+    json_name: "resourceLogs"
+  )
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:partial_success, 1,
+    type: OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess,
+    json_name: "partialSuccess"
+  )
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:rejected_log_records, 1, type: :int64, json_name: "rejectedLogRecords")
+  field(:error_message, 2, type: :string, json_name: "errorMessage")
+end

--- a/lib/otel_metric_exporter/opentelemetry/proto/logs/v1/logs.pb.ex
+++ b/lib/otel_metric_exporter/opentelemetry/proto/logs/v1/logs.pb.ex
@@ -1,0 +1,113 @@
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.SeverityNumber do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:SEVERITY_NUMBER_UNSPECIFIED, 0)
+  field(:SEVERITY_NUMBER_TRACE, 1)
+  field(:SEVERITY_NUMBER_TRACE2, 2)
+  field(:SEVERITY_NUMBER_TRACE3, 3)
+  field(:SEVERITY_NUMBER_TRACE4, 4)
+  field(:SEVERITY_NUMBER_DEBUG, 5)
+  field(:SEVERITY_NUMBER_DEBUG2, 6)
+  field(:SEVERITY_NUMBER_DEBUG3, 7)
+  field(:SEVERITY_NUMBER_DEBUG4, 8)
+  field(:SEVERITY_NUMBER_INFO, 9)
+  field(:SEVERITY_NUMBER_INFO2, 10)
+  field(:SEVERITY_NUMBER_INFO3, 11)
+  field(:SEVERITY_NUMBER_INFO4, 12)
+  field(:SEVERITY_NUMBER_WARN, 13)
+  field(:SEVERITY_NUMBER_WARN2, 14)
+  field(:SEVERITY_NUMBER_WARN3, 15)
+  field(:SEVERITY_NUMBER_WARN4, 16)
+  field(:SEVERITY_NUMBER_ERROR, 17)
+  field(:SEVERITY_NUMBER_ERROR2, 18)
+  field(:SEVERITY_NUMBER_ERROR3, 19)
+  field(:SEVERITY_NUMBER_ERROR4, 20)
+  field(:SEVERITY_NUMBER_FATAL, 21)
+  field(:SEVERITY_NUMBER_FATAL2, 22)
+  field(:SEVERITY_NUMBER_FATAL3, 23)
+  field(:SEVERITY_NUMBER_FATAL4, 24)
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecordFlags do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:LOG_RECORD_FLAGS_DO_NOT_USE, 0)
+  field(:LOG_RECORD_FLAGS_TRACE_FLAGS_MASK, 255)
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogsData do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:resource_logs, 1,
+    repeated: true,
+    type: OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ResourceLogs,
+    json_name: "resourceLogs"
+  )
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ResourceLogs do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:resource, 1, type: OtelMetricExporter.Opentelemetry.Proto.Resource.V1.Resource)
+
+  field(:scope_logs, 2,
+    repeated: true,
+    type: OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ScopeLogs,
+    json_name: "scopeLogs"
+  )
+
+  field(:schema_url, 3, type: :string, json_name: "schemaUrl")
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ScopeLogs do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:scope, 1, type: OtelMetricExporter.Opentelemetry.Proto.Common.V1.InstrumentationScope)
+
+  field(:log_records, 2,
+    repeated: true,
+    type: OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord,
+    json_name: "logRecords"
+  )
+
+  field(:schema_url, 3, type: :string, json_name: "schemaUrl")
+end
+
+defmodule OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:time_unix_nano, 1, type: :fixed64, json_name: "timeUnixNano")
+  field(:observed_time_unix_nano, 11, type: :fixed64, json_name: "observedTimeUnixNano")
+
+  field(:severity_number, 2,
+    type: OtelMetricExporter.Opentelemetry.Proto.Logs.V1.SeverityNumber,
+    json_name: "severityNumber",
+    enum: true
+  )
+
+  field(:severity_text, 3, type: :string, json_name: "severityText")
+  field(:body, 5, type: OtelMetricExporter.Opentelemetry.Proto.Common.V1.AnyValue)
+
+  field(:attributes, 6,
+    repeated: true,
+    type: OtelMetricExporter.Opentelemetry.Proto.Common.V1.KeyValue
+  )
+
+  field(:dropped_attributes_count, 7, type: :uint32, json_name: "droppedAttributesCount")
+  field(:flags, 8, type: :fixed32)
+  field(:trace_id, 9, type: :bytes, json_name: "traceId")
+  field(:span_id, 10, type: :bytes, json_name: "spanId")
+  field(:event_name, 12, type: :string, json_name: "eventName")
+end

--- a/lib/otel_metric_exporter/otel_api.ex
+++ b/lib/otel_metric_exporter/otel_api.ex
@@ -1,0 +1,125 @@
+defmodule OtelMetricExporter.OtelApi do
+  @moduledoc false
+  alias OtelMetricExporter.Protocol
+
+  @type protocol :: :http_protobuf
+  @type compression :: :gzip | nil
+
+  @public_options [
+    otlp_endpoint: [
+      type: :string,
+      required: true,
+      doc: "Endpoint to send data to."
+    ],
+    otlp_protocol: [
+      type: {:in, [:http_protobuf]},
+      type_spec: quote(do: protocol()),
+      default: :http_protobuf,
+      doc: "Protocol to use for OTLP export. Currently only `:http_protobuf` is supported."
+    ],
+    otlp_headers: [
+      type: {:map, :string, :string},
+      default: %{},
+      doc: "Headers to send with OTLP requests."
+    ],
+    otlp_compression: [
+      type: {:in, [:gzip, nil]},
+      default: :gzip,
+      type_spec: quote(do: compression()),
+      doc: "Compression to use for OTLP requests. Allowed values are `:gzip` and `nil`."
+    ],
+    otlp_concurrent_requests: [
+      type: :non_neg_integer,
+      default: 10,
+      doc: "Number of concurrent requests to send to the OTLP endpoint."
+    ],
+    resource: [
+      type: :map,
+      default: %{},
+      doc: "Resource attributes to send with collected data."
+    ]
+  ]
+
+  @schema NimbleOptions.new!(
+            [
+              finch: [
+                type: {:or, [:atom, :pid]},
+                required: true,
+                doc: "Finch process pid or registered name to use for sending requests."
+              ]
+            ] ++ @public_options
+          )
+
+  defstruct [:finch] ++ Keyword.keys(@public_options)
+
+  def public_options, do: @public_options
+
+  def defaults,
+    do:
+      Application.get_env(:otel_metric_exporter, __MODULE__, [])
+      |> Map.new()
+      |> Map.take(Keyword.keys(@public_options))
+
+  def new(opts) do
+    {opts, rest} = Map.split(opts, Keyword.keys(@public_options) ++ [:finch])
+
+    with {:ok, config} <- NimbleOptions.validate(Map.merge(defaults(), opts), @schema) do
+      {:ok, struct!(__MODULE__, config), rest}
+    end
+  end
+
+  def send_log_events(%__MODULE__{} = config, events) do
+    events
+    |> Protocol.build_log_service_request(config.resource)
+    |> send_proto("/v1/logs", config)
+  end
+
+  def send_metrics(%__MODULE__{} = config, metrics) do
+    metrics
+    |> Protocol.build_metric_service_request(config.resource)
+    |> send_proto("/v1/metrics", config)
+  end
+
+  @spec send_proto(struct(), String.t(), %__MODULE__{}) :: :ok | {:error, any()}
+  defp send_proto(body, path, %__MODULE__{} = config) do
+    body
+    |> Protobuf.encode_to_iodata()
+    |> build_finch_request(path, config)
+    |> Finch.request(config.finch)
+    |> case do
+      {:ok, %{status: 200}} ->
+        :ok
+
+      {:ok, response} ->
+        {:error, {:unexpected_status, response}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp build_finch_request(body, path, %__MODULE__{} = config) do
+    Finch.build(
+      :post,
+      url(config, path),
+      Map.to_list(headers(config)),
+      maybe_compress(body, config)
+    )
+  end
+
+  defp url(%__MODULE__{} = config, path), do: config.otlp_endpoint <> path
+
+  defp headers(%__MODULE__{otlp_compression: compression} = config) do
+    [:content_type, :accept, :compression]
+    |> Enum.reduce(%{}, fn
+      :content_type, acc -> Map.put(acc, "content-type", "application/x-protobuf")
+      :accept, acc -> Map.put(acc, "accept", "application/x-protobuf")
+      :compression, acc when compression == :gzip -> Map.put(acc, "content-encoding", "gzip")
+      _, acc -> acc
+    end)
+    |> Map.merge(config.otlp_headers)
+  end
+
+  defp maybe_compress(body, %__MODULE__{otlp_compression: :gzip}), do: :zlib.gzip(body)
+  defp maybe_compress(body, _), do: body
+end

--- a/lib/otel_metric_exporter/otlp_utils.ex
+++ b/lib/otel_metric_exporter/otlp_utils.ex
@@ -1,0 +1,42 @@
+defmodule OtelMetricExporter.OtlpUtils do
+  @moduledoc false
+
+  alias OtelMetricExporter.Opentelemetry.Proto.Common.V1.{
+    AnyValue,
+    KeyValue,
+    KeyValueList,
+    ArrayValue
+  }
+
+  def build_kv(tags, key_prefix \\ "") do
+    Enum.flat_map(tags, fn {key, value} ->
+      if is_map(value) do
+        build_kv(value, key_prefix <> to_string(key) <> ".")
+      else
+        [
+          %KeyValue{
+            key: key_prefix <> to_string(key),
+            value: %AnyValue{value: to_kv_value(value)}
+          }
+        ]
+      end
+    end)
+  end
+
+  def to_kv_value(value) when is_binary(value), do: {:string_value, value}
+  def to_kv_value(value) when is_atom(value), do: {:string_value, to_string(value)}
+  def to_kv_value(value) when is_integer(value), do: {:int_value, value}
+  def to_kv_value(value) when is_float(value), do: {:double_value, value}
+  def to_kv_value(value) when is_boolean(value), do: {:bool_value, value}
+  def to_kv_value(value) when is_struct(value), do: {:string_value, to_string(value)}
+
+  def to_kv_value([{k, _} | _] = value) when is_atom(k),
+    do: {:kvlist_value, %KeyValueList{values: build_kv(value)}}
+
+  def to_kv_value(value) when is_list(value),
+    do: {:array_value, %ArrayValue{values: Enum.map(value, &%AnyValue{value: to_kv_value(&1)})}}
+
+  def to_kv_value(value) when is_tuple(value), do: to_kv_value(Tuple.to_list(value))
+  def to_kv_value(value) when is_pid(value), do: to_kv_value(inspect(value))
+  def to_kv_value(any), do: to_kv_value(inspect(any))
+end

--- a/lib/otel_metric_exporter/protocol.ex
+++ b/lib/otel_metric_exporter/protocol.ex
@@ -1,0 +1,129 @@
+defmodule OtelMetricExporter.Protocol do
+  @moduledoc false
+  alias OtelMetricExporter.Opentelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest
+  alias OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ResourceMetrics
+  alias OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ScopeMetrics
+  alias OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest
+  alias OtelMetricExporter.Opentelemetry.Proto.Common.V1.AnyValue
+  alias OtelMetricExporter.Opentelemetry.Proto.Common.V1.InstrumentationScope
+  alias OtelMetricExporter.Opentelemetry.Proto.Common.V1.KeyValueList
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ResourceLogs
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.ScopeLogs
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.SeverityNumber
+  alias OtelMetricExporter.Opentelemetry.Proto.Resource.V1.Resource
+  alias OtelMetricExporter.OtlpUtils
+
+  @doc """
+  Convert a logger event to a struct ready for protobuf encoding
+  """
+  @spec prepare_log_event(:logger.log_event(), term()) :: struct()
+  def prepare_log_event(%{level: level, msg: msg, meta: metadata}, config) do
+    time = metadata[:time] * 1000
+    # {trace_id, span_id} = extract_trace_context(metadata)
+
+    %LogRecord{
+      time_unix_nano: time,
+      observed_time_unix_nano: time,
+      severity_number: severity_number(level),
+      severity_text: Atom.to_string(level),
+      body: encode_body(msg),
+      attributes: metadata |> prepare_attributes(config) |> OtlpUtils.build_kv(),
+      dropped_attributes_count: 0,
+      flags: 0,
+      trace_id: nil,
+      span_id: nil,
+      event_name: Map.get(metadata, :event_name, nil)
+    }
+  end
+
+  defp encode_body({:string, chardata}) do
+    %AnyValue{value: {:string_value, IO.chardata_to_string(chardata)}}
+  end
+
+  defp encode_body({:report, report}) do
+    %AnyValue{value: {:key_value_list, %KeyValueList{values: OtlpUtils.build_kv(report)}}}
+  end
+
+  defp encode_body({io_format, args}) do
+    %AnyValue{value: {:string_value, :io_lib.format(io_format, args) |> IO.chardata_to_string()}}
+  end
+
+  defp severity_number(:debug), do: SeverityNumber.value(:SEVERITY_NUMBER_DEBUG)
+  defp severity_number(:info), do: SeverityNumber.value(:SEVERITY_NUMBER_INFO)
+  defp severity_number(:notice), do: SeverityNumber.value(:SEVERITY_NUMBER_INFO2)
+  defp severity_number(:warning), do: SeverityNumber.value(:SEVERITY_NUMBER_WARN)
+  defp severity_number(:error), do: SeverityNumber.value(:SEVERITY_NUMBER_ERROR)
+  defp severity_number(:critical), do: SeverityNumber.value(:SEVERITY_NUMBER_ERROR2)
+  defp severity_number(:alert), do: SeverityNumber.value(:SEVERITY_NUMBER_FATAL)
+  defp severity_number(:emergency), do: SeverityNumber.value(:SEVERITY_NUMBER_FATAL4)
+
+  defp prepare_attributes(%{crash_reason: {reason, stacktrace}} = metadata, config) do
+    message = if is_exception(reason), do: Exception.message(reason), else: inspect(reason)
+
+    type =
+      cond do
+        is_exception(reason) -> to_string(reason.__struct__)
+        reason == :nocatch -> "Uncaught throw"
+      end
+
+    metadata
+    |> Map.drop([:crash_reason])
+    |> Map.put("exception.message", message)
+    |> Map.put("exception.type", type)
+    |> Map.put("exception.stacktrace", Exception.format_stacktrace(stacktrace))
+    |> prepare_attributes(config)
+  end
+
+  defp prepare_attributes(metadata, %{metadata: metadata_to_keep, metadata_map: metadata_map}) do
+    Enum.flat_map(metadata, fn
+      {k, v} when is_binary(k) ->
+        [{k, v}]
+
+      {k, v} ->
+        case Map.fetch(metadata_map, k) do
+          {:ok, remapped_key} ->
+            [{remapped_key, v}]
+
+          :error ->
+            if k in metadata_to_keep, do: [{k, v}], else: []
+        end
+    end)
+  end
+
+  def build_log_service_request(events, resource \\ %{}) do
+    %ExportLogsServiceRequest{
+      resource_logs: [
+        %ResourceLogs{
+          resource: %Resource{
+            attributes: OtlpUtils.build_kv(resource)
+          },
+          scope_logs: [
+            %ScopeLogs{
+              scope: %InstrumentationScope{
+                name: "otel_metric_exporter"
+              },
+              log_records: events
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  def build_metric_service_request(metrics, resource \\ %{}) do
+    %ExportMetricsServiceRequest{
+      resource_metrics: [
+        %ResourceMetrics{
+          resource: %Resource{attributes: OtlpUtils.build_kv(resource)},
+          scope_metrics: [
+            %ScopeMetrics{
+              scope: %InstrumentationScope{name: "otel_metric_exporter"},
+              metrics: metrics
+            }
+          ]
+        }
+      ]
+    }
+  end
+end

--- a/lib/otel_metric_exporter/protocol.ex
+++ b/lib/otel_metric_exporter/protocol.ex
@@ -31,8 +31,9 @@ defmodule OtelMetricExporter.Protocol do
       attributes: metadata |> prepare_attributes(config) |> OtlpUtils.build_kv(),
       dropped_attributes_count: 0,
       flags: 0,
-      trace_id: nil,
-      span_id: nil,
+      # Official OTel tracing library adds these as charlists, so we need to convert them to binaries
+      trace_id: Map.get(metadata, :otel_trace_id, nil) |> to_string(),
+      span_id: Map.get(metadata, :otel_span_id, nil) |> to_string(),
       event_name: Map.get(metadata, :event_name, nil)
     }
   end

--- a/test/otel_metric_exporter/log_handler_supervisor_test.exs
+++ b/test/otel_metric_exporter/log_handler_supervisor_test.exs
@@ -1,0 +1,140 @@
+defmodule OtelMetricExporter.LogHandlerSupervisorTest do
+  use ExUnit.Case
+
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord
+  alias OtelMetricExporter.Opentelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest
+  alias OtelMetricExporter.LogAccumulator
+  alias OtelMetricExporter.LogHandlerSupervisor
+
+  setup do
+    bypass = Bypass.open()
+
+    {:ok, config} =
+      LogAccumulator.check_config(%{
+        otlp_endpoint: "http://localhost:#{bypass.port}",
+        resource: %{instance: %{id: "test"}},
+        debounce_ms: 100,
+        max_buffer_size: 20
+      })
+
+    {:ok, %{bypass: bypass, config: config}}
+  end
+
+  test "starts the supervisor and the accumulator with overload protection", %{config: config} do
+    {:ok, supervisor_pid, olp} =
+      LogHandlerSupervisor.start_link(
+        name: :test_log_handler_supervisor,
+        accumulator_config: config,
+        olp_config: %{}
+      )
+
+    on_exit(fn ->
+      Process.exit(supervisor_pid, :shutdown)
+    end)
+
+    assert Process.alive?(supervisor_pid)
+    assert :logger_olp.get_pid(olp) |> Process.alive?()
+  end
+
+  test "sends logs after debounce period has passed", %{bypass: bypass, config: config} do
+    {:ok, _, olp} =
+      LogHandlerSupervisor.start_link(
+        name: :test_log_handler_supervisor,
+        accumulator_config: config,
+        olp_config: %{}
+      )
+
+    parent = self()
+
+    Bypass.expect_once(bypass, "POST", "/v1/logs", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert {"content-type", "application/x-protobuf"} in conn.req_headers
+      assert {"accept", "application/x-protobuf"} in conn.req_headers
+      assert {"content-encoding", "gzip"} in conn.req_headers
+      assert body != ""
+
+      %ExportLogsServiceRequest{resource_logs: [%{scope_logs: [%{log_records: logs}]}]} =
+        body |> :zlib.gunzip() |> Protobuf.decode(ExportLogsServiceRequest)
+
+      assert length(logs) == 5
+
+      assert Enum.all?(
+               logs,
+               &match?(%LogRecord{body: %{value: {:string_value, "test log" <> _}}}, &1)
+             )
+
+      send(parent, :done)
+
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    for i <- 1..5 do
+      :logger_olp.load(
+        olp,
+        LogAccumulator.prepare_log_event(
+          %{
+            level: :info,
+            msg: {:string, "test log #{i}"},
+            meta: %{time: System.system_time(:millisecond)}
+          },
+          config
+        )
+      )
+    end
+
+    assert_receive :done, 1000
+    Process.sleep(100)
+  end
+
+  test "sends logs immediately once the limit is hit", %{bypass: bypass, config: config} do
+    {:ok, _, olp} =
+      LogHandlerSupervisor.start_link(
+        name: :test_log_handler_supervisor,
+        accumulator_config: %{config | max_buffer_size: 5, debounce_ms: 30_000},
+        olp_config: %{}
+      )
+
+    parent = self()
+
+    Bypass.expect_once(bypass, "POST", "/v1/logs", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert {"content-type", "application/x-protobuf"} in conn.req_headers
+      assert {"accept", "application/x-protobuf"} in conn.req_headers
+      assert {"content-encoding", "gzip"} in conn.req_headers
+      assert body != ""
+
+      %ExportLogsServiceRequest{resource_logs: [%{scope_logs: [%{log_records: logs}]}]} =
+        body |> :zlib.gunzip() |> Protobuf.decode(ExportLogsServiceRequest)
+
+      assert length(logs) == 5
+
+      assert Enum.all?(
+               logs,
+               &match?(%LogRecord{body: %{value: {:string_value, "test log" <> _}}}, &1)
+             )
+
+      send(parent, :done)
+
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    for i <- 1..5 do
+      :logger_olp.load(
+        olp,
+        LogAccumulator.prepare_log_event(
+          %{
+            level: :info,
+            msg: {:string, "test log #{i}"},
+            meta: %{time: System.system_time(:millisecond)}
+          },
+          config
+        )
+      )
+    end
+
+    assert_receive :done, 1000
+    Process.sleep(100)
+  end
+end

--- a/test/otel_metric_exporter/log_handler_supervisor_test.exs
+++ b/test/otel_metric_exporter/log_handler_supervisor_test.exs
@@ -127,7 +127,10 @@ defmodule OtelMetricExporter.LogHandlerSupervisorTest do
           %{
             level: :info,
             msg: {:string, "test log #{i}"},
-            meta: %{time: System.system_time(:millisecond)}
+            meta: %{
+              time: System.system_time(:millisecond),
+              otel_trace_id: ~C"00000000000000000000000000000000"
+            }
           },
           config
         )


### PR DESCRIPTION
- It's implemented as an [OTP log handler](https://hexdocs.pm/logger/Logger.html#module-erlang-otp-handlers)
- It reuses [overload protection](https://www.erlang.org/doc/apps/kernel/logger_chapter#protecting-the-handler-from-overload) employed by the console logger
- It batches log events before pushing them to OTel server, with 10000 event batches or 5 second debounce windows
- It uses a Finch pool to send the events, with a configurable concurrency (of 10 by default) to send a batch but don't block until HTTP request is successful. At most 10 batches can be in flight, at which point the log handler blocks until at least one spot is opened
- The overload protection is configured to not have `:sync` mode described in the aforementioned docs, because blocking a logging caller until HTTP call resolves is unreasonable. Thus it's employed in 2 modes: async, or flush - if message queue of the process reaches a configured boundary (200 messages), it will be flushed to not result in memory leaks.