### PR TITLE
fix: Put the correct bytes in for span and trace ids

### DIFF
--- a/lib/otel_metric_exporter/protocol.ex
+++ b/lib/otel_metric_exporter/protocol.ex
@@ -31,11 +31,16 @@ defmodule OtelMetricExporter.Protocol do
       attributes: metadata |> prepare_attributes(config) |> OtlpUtils.build_kv(),
       dropped_attributes_count: 0,
       flags: 0,
-      # Official OTel tracing library adds these as charlists, so we need to convert them to binaries
-      trace_id: Map.get(metadata, :otel_trace_id, nil) |> to_string(),
-      span_id: Map.get(metadata, :otel_span_id, nil) |> to_string(),
+      # Official OTel tracing library adds these
+      trace_id: Map.get(metadata, :otel_trace_id, nil) |> hex_to_bytes(),
+      span_id: Map.get(metadata, :otel_span_id, nil) |> hex_to_bytes(),
       event_name: Map.get(metadata, :event_name, nil)
     }
+  end
+
+  defp hex_to_bytes(hex_string) do
+    # Converts the otel hex chatlist/string into the underlying bytes
+    hex_string |> to_string() |> Base.decode16!(case: :mixed)
   end
 
   defp encode_body({:string, chardata}) do

--- a/test/otel_metric_exporter/log_handler_integration_test.exs
+++ b/test/otel_metric_exporter/log_handler_integration_test.exs
@@ -431,8 +431,8 @@ defmodule OtelMetricExporter.LogHandlerIntegrationTest do
         Tracer.current_span_ctx()
       end
 
-    trace_id = :otel_span.hex_trace_id(span) |> to_string()
-    span_id = :otel_span.hex_span_id(span) |> to_string()
+    trace_id = :otel_span.hex_trace_id(span) |> Base.decode16!(case: :mixed)
+    span_id = :otel_span.hex_span_id(span) |> Base.decode16!(case: :mixed)
 
     assert_receive {:logs, logs}, 500
 


### PR DESCRIPTION
The `LogRecord` expects the `trace_id` and `span_id` fields to be bytes. By putting in the hex_string in these fields directly is downstream providers will essentially encode16 the already encoded 16 IDs.

By first calling `decode16` first we are properly putting in the raw bytes of the IDs into the protobuf before sending down to providers.

Below you can see what this library was sending to Honeycomb. We added the raw `otel_trace_id` and `otel_span_id` as attributes for comparison. 

<img width="1300" height="168" alt="Screenshot 2025-08-28 at 5 04 26 PM" src="https://github.com/user-attachments/assets/b223d7e5-3bb9-451e-882e-f03bff2f3826" />

You'll see the traces that Honeycomb are getting are essentially double base 16ed. 

```
iex(1)> Base.decode16!("3035333364303531313266323734623530343636336239313231303364373238")
"0533d05112f274b504663b912103d728"
```