### PR TITLE
Handle :undefined in MetricStore.convert_value/2

### DIFF
--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -383,11 +383,15 @@ defmodule OtelMetricExporter.MetricStore do
   defp convert_unit(:terabyte), do: "TBy"
   defp convert_unit(x) when is_atom(x), do: Atom.to_string(x)
 
-  # These two clauses are here to preserve the current behaviour of the library and avoid
-  # introducing unexpected errors. Ideally, we would filter these nil values higher up in the
-  # call stack and stop short of exporting metrics with nil values.
+  # These clauses are here to preserve the current behaviour of the library and avoid
+  # introducing unexpected errors. Ideally, we would filter these nil/:undefined values higher
+  # up in the call stack and stop short of exporting metrics with nil values.
+  #
+  # `:telemetry` emits `:undefined` for uninitialised values, so we treat it the same as `nil`.
   defp convert_value(nil, :int), do: {:as_int, nil}
   defp convert_value(nil, :double), do: {:as_double, nil}
+  defp convert_value(:undefined, :int), do: {:as_int, nil}
+  defp convert_value(:undefined, :double), do: {:as_double, nil}
 
   @signed_int64_max 2 ** 63 - 1
   @signed_int64_min -2 ** 63

--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -153,29 +153,35 @@ defmodule OtelMetricExporter.MetricStoreTest do
       assert MetricStore.get_metrics(@name, 0) == %{}
     end
 
-    test "exports :undefined last_value as a nil data point without crashing", %{
+    test "exports nil and :undefined last_value as a nil data point without crashing", %{
       bypass: bypass,
       store_config: config
     } do
-      metric = Metrics.last_value("test.last_value.undefined")
+      metric_undef = Metrics.last_value("test.last_value.undefined")
+      metric_nil = Metrics.last_value("test.last_value.nil")
       tags = %{test: "value"}
-      start_supervised!({MetricStore, %{config | metrics: [metric]}})
+      start_supervised!({MetricStore, %{config | metrics: [metric_undef, metric_nil]}})
 
       Bypass.expect_once(bypass, "POST", "/v1/metrics", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = ExportMetricsServiceRequest.decode(body)
 
-        assert [%{scope_metrics: [%{metrics: [exported]}]}] = decoded.resource_metrics
-        assert {:gauge, %{data_points: [point]}} = exported.data
-        # protobuf elides the nil inner value, so the oneof decodes as nil
-        assert point.value == nil
+        assert [%{scope_metrics: [%{metrics: exported_metrics}]}] = decoded.resource_metrics
+
+        Enum.each(exported_metrics, fn metric ->
+          assert {:gauge, %{data_points: [point]}} = metric.data
+          # protobuf elides the nil inner value, so the oneof decodes as nil
+          assert point.value == nil
+        end)
 
         Plug.Conn.resp(conn, 200, "")
       end)
 
-      # `:telemetry` emits `:undefined` for uninitialised values; previously this crashed the
-      # export pipeline with a FunctionClauseError in convert_value/2.
-      MetricStore.write_metric(@name, metric, :undefined, tags)
+      # `:telemetry` emits `:undefined` for uninitialised values
+      MetricStore.write_metric(@name, metric_undef, :undefined, tags)
+
+      # A `nil` value may slip in just as well
+      MetricStore.write_metric(@name, metric_nil, nil, tags)
 
       assert :ok = MetricStore.export_sync(@name)
     end

--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -153,6 +153,33 @@ defmodule OtelMetricExporter.MetricStoreTest do
       assert MetricStore.get_metrics(@name, 0) == %{}
     end
 
+    test "exports :undefined last_value as a nil data point without crashing", %{
+      bypass: bypass,
+      store_config: config
+    } do
+      metric = Metrics.last_value("test.last_value.undefined")
+      tags = %{test: "value"}
+      start_supervised!({MetricStore, %{config | metrics: [metric]}})
+
+      Bypass.expect_once(bypass, "POST", "/v1/metrics", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = ExportMetricsServiceRequest.decode(body)
+
+        assert [%{scope_metrics: [%{metrics: [exported]}]}] = decoded.resource_metrics
+        assert {:gauge, %{data_points: [point]}} = exported.data
+        # protobuf elides the nil inner value, so the oneof decodes as nil
+        assert point.value == nil
+
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      # `:telemetry` emits `:undefined` for uninitialised values; previously this crashed the
+      # export pipeline with a FunctionClauseError in convert_value/2.
+      MetricStore.write_metric(@name, metric, :undefined, tags)
+
+      assert :ok = MetricStore.export_sync(@name)
+    end
+
     test "handles server errors gracefully", %{bypass: bypass, store_config: config} do
       metric = Metrics.sum("test.sum")
       tags = %{test: "value"}


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

`OtelMetricExporter.MetricStore.convert_value/2` matches on `nil`, integers, and floats, but Erlang `:telemetry` emits `:undefined` for uninitialised values. Receiving `convert_value(:undefined, :double)` currently crashes with `FunctionClauseError`, taking down the metric reporter.

This adds two clauses that treat `:undefined` identically to `nil`, preserving the existing behaviour (emit a data point with a `nil` value) instead of crashing.

## Context

Reported via electric-sql/stratovolt#1454 (Sentry issue ELECTRIC-7RH, 10 events).

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [ ] Verify in stratovolt that the Sentry error no longer reproduces after consuming this fix