### PR TITLE
Handle unexpected messages in LogAccumulator

### DIFF
--- a/lib/otel_metric_exporter/log_accumulator.ex
+++ b/lib/otel_metric_exporter/log_accumulator.ex
@@ -139,6 +139,18 @@ defmodule OtelMetricExporter.LogAccumulator do
     {:noreply, %{state | pending_tasks: Map.delete(state.pending_tasks, ref)}}
   end
 
+  # Catch-all for unexpected messages. Without this, the process would crash on
+  # any stray message (e.g. a late task reply after the task ref was forgotten,
+  # or monitor/EXIT signals from unrelated processes), which would take down the
+  # logger handler. Log and carry on instead.
+  def handle_info(msg, state) do
+    Logger.debug(fn ->
+      "#{inspect(__MODULE__)} received unexpected message: #{inspect(msg)}"
+    end)
+
+    {:noreply, state}
+  end
+
   def terminate(_reason, state) do
     # Send any remaining logs if possible
     send_events_via_task(state)

--- a/test/otel_metric_exporter/log_accumulator_test.exs
+++ b/test/otel_metric_exporter/log_accumulator_test.exs
@@ -1,0 +1,34 @@
+defmodule OtelMetricExporter.LogAccumulatorTest do
+  use ExUnit.Case, async: true
+
+  alias OtelMetricExporter.LogAccumulator
+
+  describe "handle_info/2" do
+    test "ignores unexpected messages without crashing" do
+      state = %{pending_tasks: %{}}
+
+      assert {:noreply, ^state} = LogAccumulator.handle_info(:some_unexpected_message, state)
+      assert {:noreply, ^state} = LogAccumulator.handle_info({:foo, :bar}, state)
+      assert {:noreply, ^state} = LogAccumulator.handle_info({:EXIT, self(), :normal}, state)
+    end
+
+    test "ignores task reply with unknown ref without crashing" do
+      state = %{pending_tasks: %{}}
+      unknown_ref = make_ref()
+
+      assert {:noreply, ^state} =
+               LogAccumulator.handle_info({unknown_ref, {:ok, :done}}, state)
+    end
+
+    test "ignores DOWN message with unknown ref without crashing" do
+      state = %{pending_tasks: %{}}
+      unknown_ref = make_ref()
+
+      assert {:noreply, ^state} =
+               LogAccumulator.handle_info(
+                 {:DOWN, unknown_ref, :process, self(), :normal},
+                 state
+               )
+    end
+  end
+end


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary
- Add a catch-all `handle_info/2` clause on `OtelMetricExporter.LogAccumulator` so unexpected messages no longer crash the logger handler process.
- The catch-all logs the message at debug level and leaves state unchanged.

## Context
The accumulator is used as a `:logger_olp` callback and previously had no catch-all `handle_info/2`. Any stray message (e.g. a late task reply after its ref was forgotten, a `:DOWN`/`:EXIT` signal from an unrelated process, or arbitrary traffic from other libs) would cause a `FunctionClauseError`, taking down the logger handler.

Fixes the behavior reported in electric-sql/stratovolt#1456.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] New `test/otel_metric_exporter/log_accumulator_test.exs` exercises `handle_info/2` with unexpected messages, unknown task refs, and unknown `:DOWN` refs.
- [x] Full `mix test` suite (47 tests) passes.