### PR TITLE
Add nil check before writing metric to store

### DIFF
--- a/lib/otel_metric_exporter.ex
+++ b/lib/otel_metric_exporter.ex
@@ -138,7 +138,9 @@ defmodule OtelMetricExporter do
         tags = extract_tags(metric, metadata)
 
         metric_name = "#{Enum.join(metric.name, ".")}"
-        MetricStore.write_metric(name, metric, metric_name, value, tags)
+        if not is_nil(value) do
+          MetricStore.write_metric(name, metric, metric_name, value, tags)
+        end
       end
     end
   rescue


### PR DESCRIPTION
It is possible that a metric key might not exist in the measurements map. This happens with some Ecto measurements.