### PR TITLE
fix: use delta base aggregation to fit current export behaviour

### DIFF
--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -297,7 +297,7 @@ defmodule OtelMetricExporter.MetricStore do
              value: convert_value(value, :int)
            }
          end),
-       aggregation_temporality: :AGGREGATION_TEMPORALITY_CUMULATIVE,
+       aggregation_temporality: :AGGREGATION_TEMPORALITY_DELTA,
        is_monotonic: true
      }}
   end
@@ -314,7 +314,7 @@ defmodule OtelMetricExporter.MetricStore do
              value: convert_value(value, :int)
            }
          end),
-       aggregation_temporality: :AGGREGATION_TEMPORALITY_CUMULATIVE,
+       aggregation_temporality: :AGGREGATION_TEMPORALITY_DELTA,
        is_monotonic: false
      }}
   end
@@ -367,7 +367,7 @@ defmodule OtelMetricExporter.MetricStore do
              max: max_value && max_value / 1
            }
          end),
-       aggregation_temporality: :AGGREGATION_TEMPORALITY_CUMULATIVE
+       aggregation_temporality: :AGGREGATION_TEMPORALITY_DELTA
      }}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule OtelMetricExporter.MixProject do
       app: :otel_metric_exporter,
       name: "OTel Metric Exporter",
       description: "An unofficial OTel-compatible metric exporter",
-      version: "0.4.4",
+      version: "0.4.5",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/electric-sql/elixir-otel-metric-exporter",


### PR DESCRIPTION
The current metric store implementation clear all the metrics after sending it to the OTLP endpoint at
lib/otel_metric_exporter/metric_store.ex:226.

This implementation fits the Delta Temporal Aggregation method of sending metrics where we send the delta between the last export as compared to the currently configured Cumulative Temporal Aggregation where we would instead send the accumulation of all metrics since the start of the application on every export. More information can be found in the OTEL docs here:
https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality

This doesn't cause an issue with Prometheus since it uses `start_time_unix_nano` from the exported metric to trigger reset detection. Since we update this start time on every new export, this essentially means that reset detection is triggered for every new "cummulative" metric export. Prometheus seems to handle gracefully even though it can lead to some innacuracies from what I heard. On the other hand, providers like New Relic doesn't seem to handle this as gracefully and makes the metric unusable for reasons unknown to me at this moment.

The change the Delta Temporal Aggregation does fix the issue for New Relic, on top of reducing unnecessary work for Premetheus.